### PR TITLE
Update to be compatible with html.parser v3.5, remove uncalled code

### DIFF
--- a/html_table_parser/parser.py
+++ b/html_table_parser/parser.py
@@ -23,9 +23,8 @@ class HTMLTableParser(HTMLParser):
         data_separator=' ',
     ):
 
-        HTMLParser.__init__(self)
+        HTMLParser.__init__(self, convert_charrefs=decode_html_entities)
 
-        self._parse_html_entities = decode_html_entities
         self._data_separator = data_separator
 
         self._in_td = False
@@ -48,13 +47,7 @@ class HTMLTableParser(HTMLParser):
         """ This is where we save content to a cell """
         if self._in_td or self._in_th:
             self._current_cell.append(data.strip())
-
-    def handle_charref(self, name):
-        """ Handle HTML encoded characters """
-
-        if self._parse_html_entities:
-            self.handle_data(self.unescape('&#{};'.format(name)))
-
+    
     def handle_endtag(self, tag):
         """ Here we exit the tags. If the closing tag is </tr>, we know that we
         can save our currently parsed cells to the current table as a row and


### PR DESCRIPTION
As of `html.parser` version 3.5, the `handle_charref()` method never gets called. 
This is because `HTMLParser.__init__()` now sets a flag to automatically decode character references and entity references. This flag is configurable, but by default is set to `True`.

From the [html.parser docs](https://docs.python.org/3/library/html.parser.html#):

> Changed in version 3.5: The default value for argument `convert_charrefs` is now `True`.

> If `convert_charrefs` is `True` (the default), all character references (except the ones in script/style elements) are automatically converted to the corresponding Unicode characters.

This commit makes the parser compatible with `html.parser` v3.5; in particular, the call to `HTMLParser.__init__()`

Note that `HTMLParser` calls `unescape()` itself when handling data (if _convert_charrefs_ is set to `True`). Therefore, overriding `handle_charref()` is no longer needed.