### PR TITLE
Remove Deprecated Typing.List

### DIFF
--- a/html_table_parser/parser.py
+++ b/html_table_parser/parser.py
@@ -11,7 +11,6 @@
 # -----------------------------------------------------------------------------
 
 from html.parser import HTMLParser
-from typing import List
 
 
 class HTMLTableParser(HTMLParser):
@@ -37,7 +36,7 @@ class HTMLTableParser(HTMLParser):
         self.named_tables = {}
         self.name = ""
 
-    def handle_starttag(self, tag: str, attrs: List) -> None:
+    def handle_starttag(self, tag: str, attrs: list) -> None:
         """ We need to remember the opening point for the content of interest.
         The other tags (<table>, <tr>) are only handled at the closing point.
         """

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,5 +1,4 @@
 from os import path
-from typing import List
 import unittest
 
 from html_table_parser import HTMLTableParser
@@ -10,7 +9,7 @@ class ParserTest(unittest.TestCase):
             return f.read()
         self.assertTrue(False, "Invalid test_input file name")
 
-    def checkTableValues(self, actual: List[List[str]], num_rows: int, num_cols: int, expected_values: List[str]):
+    def checkTableValues(self, actual: list[list[str]], num_rows: int, num_cols: int, expected_values: list[str]):
         self.assertEqual(num_rows, len(actual))
         self.assertTrue(all([len(a) == num_cols for a in actual]))
         current_cell_index = 0
@@ -20,7 +19,7 @@ class ParserTest(unittest.TestCase):
                 self.assertEqual(expected_values[current_cell_index], actual[r][c])
                 current_cell_index = current_cell_index + 1
 
-    def checkNumericTableValues(self, actual: List[List[str]], num_rows: int, num_cols: int, initial_value: int):
+    def checkNumericTableValues(self, actual: list[list[str]], num_rows: int, num_cols: int, initial_value: int):
         expected_values = [str(i) for i in range(initial_value, num_rows * num_cols + initial_value)]
         self.checkTableValues(actual, num_rows, num_cols, expected_values)
 
@@ -112,5 +111,5 @@ class ParserTest(unittest.TestCase):
         expected_first_row = ['', '1', '2']
         expected_second_row = ['10', '11', '12']
         self.assertEqual(2, len(outer_table))
-        self.assertListEqual(outer_table[0], expected_first_row)
-        self.assertListEqual(outer_table[1], expected_second_row)
+        self.assertlistEqual(outer_table[0], expected_first_row)
+        self.assertlistEqual(outer_table[1], expected_second_row)


### PR DESCRIPTION
Proposed Change: Remove deprecated Typing.List usage and replace with generic list. 

Typing.List is expected to be removed in 2025